### PR TITLE
Fix .travis.yml link bug

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -15,7 +15,7 @@ link_dotfiles() {
     find "$src_dir" -maxdepth 1 \
     \( -name '.*' -or -name gitignore \) \
     -type f \
-    -not -name '.*.swp' -not -name '.gitignore' -not -name .bashrc \
+    -not -name '.*.swp' -not -name '.gitignore' -not -name .bashrc -not -name .travis.yml \
     -print \
     | while read f; do
         local fil="$target_dir/$(basename "$f")"

--- a/test/test_link_dotfiles.sh
+++ b/test/test_link_dotfiles.sh
@@ -8,6 +8,8 @@ testEmptyTargetDir() {
     assertTrue "Links .gitconfig" "[ -L \"$target_dir\"/.gitconfig ]"
     assertTrue "Links .vimrc" "[ -L \"$target_dir\"/.vimrc ]"
     assertTrue "Links .tmux.conf" "[ -L \"$target_dir\"/.tmux.conf ]"
+    assertFalse "Does not link .bashrc" "[ -L \"$target_dir\"/.bashrc ]"
+    assertFalse "Does not link .travis.yml" "[ -L \"$target_dir\"/.travis.yml ]"
     rm -r "$target_dir"
 }
 


### PR DESCRIPTION
The relatively recently added .travis.yml was not exluded in the make.sh
install script, so a link to it was added to the home dir.

This commit fixes the bug and adds tests for it.