### PR TITLE
Add CARGO_NET_GIT_FETCH_WITH_CLI=true

### DIFF
--- a/aliases.sh
+++ b/aliases.sh
@@ -73,6 +73,8 @@ gitlog() {
 EOF
 export -f gitlog
 
+export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 # Somewhat weird form to support Bash 3:
 source /dev/stdin <<<"$(source "$my_dir"/gitlog.sh && type ccut | sed '1d')"
 export -f ccut


### PR DESCRIPTION
to avoid:

```
$ cargo build
    Updating crates.io index
error: failed to get `anyhow` as a dependency of package [...]

Caused by:
  failed to fetch `https://github.com/rust-lang/crates.io-index`

Caused by:
  failed to authenticate when downloading repository: git@github.com:rust-lang/crates.io-index

  * attempted ssh-agent authentication, but no usernames succeeded: `git`

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
Caused by:
  no authentication available
```

when .gitconfig contains:

```
[url "git@github.com:"]
        insteadOf = https://github.com/
```