### PR TITLE
Fix bug where file is mistaken for commit

### DIFF
--- a/gitlog.sh
+++ b/gitlog.sh
@@ -607,6 +607,8 @@ forward_page() {
 
 get_commit() {
     _line="$(printf '%s\n' "$lines" | line_at "${1:-$index}")"
+    {
+    set -f
     for _w in $_line; do
         case "$_w" in
             *[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
@@ -614,7 +616,9 @@ get_commit() {
                 break
             ;;
         esac
-    done | nocolors
+    done
+    set +f
+    } | nocolors
 }
 
 line_at() {


### PR DESCRIPTION
Example to reproduce:

File in repo: 12-95-3424183821.xml

_line='  *   31c04bd 2021-09-29  (HEAD -> exception, tag: master-31c04bd, origin/master, origin/HEAD, master) Merge'

The * extanded to file names in directory and tried to match commit pattern.

Use `set -f` defined in POSIX:

> The shell shall disable pathname expansion.

This looks like it was correct earlier, but changed in 7768a85