### PR TITLE
Change imagemagick image

### DIFF
--- a/docker_aliases.sh
+++ b/docker_aliases.sh
@@ -165,7 +165,7 @@ for cmd in compare composite convert identify magick mogrify montage stream ; do
         source /dev/stdin <<-EOF
 		$cmd() {
 		    echo>/dev/null "See $my_dir for source"
-		    docker run --rm --network none -u "$user_string" -v "\$(pwd)":/dir$vol_opt -w /dir v4tech/imagemagick@sha256:959eb75b13efb41a8f37495784150574d66175adebd0c6c18216b482c574d109 $cmd "\$@"
+		    docker run --rm -i --network none -u "$user_string" -v "\$(pwd)":/dir$vol_opt -w /dir acleancoder/imagemagick-full $cmd "\$@"
 		}
 		EOF
         export -f $cmd


### PR DESCRIPTION
Because SVG, with text, should work:

```
docker run --rm -i --network none -u "$(id -u):$(id -g)" -v "$(pwd)":/dir$(selinuxenabled 2>/dev/null && echo :Z) -w /dir acleancoder/imagemagick-full convert - out.png <<EOF
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
 "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg height="100" width="100">
  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="white" />
  <text x="30" y="50">Hello</text>
</svg>
EOF
```

This image is a bit big, but works.

Created an issue for another image: https://gitlab.com/madhead-docker/imagemagick/-/issues/3