### PR TITLE
gitlog trap EXIT

### DIFF
--- a/gitlog.sh
+++ b/gitlog.sh
@@ -707,7 +707,7 @@ nocolors_line() {
         then
             _ansi="$(expr " $_rest" : " \(\[[0-9;]*[A-Za-z]\)")"
             if [ -n "$_ansi" ]; then
-                _rest="${_rest##$_ansi}"
+                _rest="${_rest##"$_ansi"}"
                 continue
             fi
         fi


### PR DESCRIPTION
Catches exceptions (`set -e` / `errexit`) and normal exits.

Add clear before commands that may fail for a more pleasant read of error output.

Add clear function.